### PR TITLE
Adding IncludeDiagnostics to WriteTo extension method, and adding some unit tests.

### DIFF
--- a/Serilog.LogglyBulkSink.Tests/Serilog.LogglyBulkSink.Tests.csproj
+++ b/Serilog.LogglyBulkSink.Tests/Serilog.LogglyBulkSink.Tests.csproj
@@ -70,7 +70,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="UnitTest1.cs" />
+    <Compile Include="SerilogLogglyBulkSinkTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Serilog.LogglyBulkSink/LogglyBulkSinkExtension.cs
+++ b/Serilog.LogglyBulkSink/LogglyBulkSinkExtension.cs
@@ -2,7 +2,7 @@
 using Serilog.Configuration;
 using Serilog.Events;
 
-namespace Serilog.LogglyBulkSink.cs
+namespace Serilog.LogglyBulkSink
 {
     public static class LogglyBulkSinkExtension
     {
@@ -15,6 +15,7 @@ namespace Serilog.LogglyBulkSink.cs
         /// <param name="restrictedToMinLevel">Minimum Log Level to Restrict to </param>
         /// <param name="batchPostingLimit">Batch Posting Limit, defaults to 1000</param>
         /// <param name="period">Frequency of Periodic Batch Sink auto flushing</param>
+        /// <param name="includeDiagnostics">Whether or not to send the Loggly Diagnostics Event</param>
         /// <returns>Original Log Sink Configuration now updated</returns>
         /// <remarks>Depending on your aveage log event size, a batch positing limit on the order of 10000 could be reasonable</remarks>
         public static LoggerConfiguration LogglyBulk(this LoggerSinkConfiguration lc, 
@@ -22,13 +23,14 @@ namespace Serilog.LogglyBulkSink.cs
             string[] logglyTags,
             LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
             int batchPostingLimit = 1000,
-            TimeSpan? period = null)
+            TimeSpan? period = null,
+            bool includeDiagnostics = false)
         {
             if (lc == null) throw new ArgumentNullException("lc");
 
             var frequency = period ?? TimeSpan.FromSeconds(30);
 
-            return lc.Sink(new LogglySink(logglyKey, logglyTags, batchPostingLimit, frequency), restrictedToMinLevel);
+            return lc.Sink(new LogglySink(logglyKey, logglyTags, batchPostingLimit, frequency, includeDiagnostics), restrictedToMinLevel);
         }
     }
 }

--- a/Serilog.LogglyBulkSink/LogglySink.cs
+++ b/Serilog.LogglyBulkSink/LogglySink.cs
@@ -79,13 +79,16 @@ namespace Serilog.LogglyBulkSink
 
         public static StringContent PackageContent(List<string> jsons, int bytes, int page, bool includeDiagnostics = false)
         {
-            var diagnostic = JsonConvert.SerializeObject(new
+            if (includeDiagnostics)
             {
-                Event = "LogglyDiagnostics",
-                Trace = string.Format("EventCount={0}, ByteCount={1}, PageCount={2}", jsons.Count, bytes, page)
-            });
+                var diagnostic = JsonConvert.SerializeObject(new
+                {
+                    Event = "LogglyDiagnostics",
+                    Trace = string.Format("EventCount={0}, ByteCount={1}, PageCount={2}", jsons.Count, bytes, page)
+                });
+                jsons.Add(diagnostic);
+            }
             
-            if (includeDiagnostics) jsons.Add(diagnostic);
             return new StringContent(string.Join("\n", jsons), Encoding.UTF8, "application/json");
         }
 


### PR DESCRIPTION
As mentioned in my commit message, I also optimized some resource usage - when include diagnostics is turned off, the sink would still create and serialize the Diagnostics message.
